### PR TITLE
Added a paths restriction to Terraform CI action

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - '**.tf'
 
 jobs:
   validate:


### PR DESCRIPTION
Action will now only run checks on PRs that modify a **.tf file.